### PR TITLE
Aligned PySide version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ PyAudio==0.2.14
 pygame==2.6.1
 pynput==1.7.7
 PySide6==6.7.3
-PySide6==6.8.0
 PySide6_Addons==6.7.3
 PySide6_Essentials==6.7.3
 rtmidi==2.5.0


### PR DESCRIPTION
Had PySide listed twice using a newer version, causing pip install error. Removed newer version to align with deps